### PR TITLE
update build dependency for test

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
     "eslint": "^2.13.1",
     "eslint-plugin-react": "^5.2.2",
     "expect": "^1.20.1",
-    "expect-jsx": "^2.6.0",
-    "mocha": "^2.5.3",
-    "react-addons-test-utils": "^15.1.0",
-    "skin-deep": "^0.16.0"
+    "expect-jsx": "^5.0.0",
+    "mocha": "^10.0.0",
+    "react-test-renderer": "^15.7.0",
+    "skin-deep": "^1.2.0"
   }
 }


### PR DESCRIPTION
I changed to "react-test-renderer" because "react-addons-test-util" is deprecated and the latest skin-deep occur errors.